### PR TITLE
feat(ushakov.telegram): webhook UI/опции, абсолютные ссылки, дедуплик…

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -99,6 +99,8 @@ class ushakov_telegram extends CModule
         $em->registerEventHandler('main', 'OnAfterUserAdd', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onUserRegistered');
         // Новая заявка (перехват почтовых событий)
         $em->registerEventHandler('main', 'OnBeforeEventAdd', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onBeforeEventAdd');
+        // Отмена заказа
+        $em->registerEventHandler('sale', 'OnSaleCancelOrder', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onSaleCancelOrder');
 
         // Агент обработки очереди (каждые 5 минут)
         // Очередь можно отключить в настройках, но агент регистрируем,
@@ -122,6 +124,7 @@ class ushakov_telegram extends CModule
         $em->unRegisterEventHandler('sale', 'OnSalePayOrder', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onOrderPay');
         $em->unRegisterEventHandler('main', 'OnAfterUserAdd', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onUserRegistered');
         $em->unRegisterEventHandler('main', 'OnBeforeEventAdd', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onBeforeEventAdd');
+        $em->unRegisterEventHandler('sale', 'OnSaleCancelOrder', $this->MODULE_ID, '\\Ushakov\\Telegram\\Events', 'onSaleCancelOrder');
 
         \CAgent::RemoveAgent("\\\\Ushakov\\\\Telegram\\\\Agent::process();", $this->MODULE_ID);
         return true;

--- a/lang/ru/options.php
+++ b/lang/ru/options.php
@@ -17,6 +17,7 @@ $MESS["USH_TG_SECTION_EVENTS"] = "<b>Какие события отправля�
 $MESS["USH_TG_OPT_SEND_ORDER_NEW"] = "Новый заказ";
 $MESS["USH_TG_OPT_SEND_ORDER_STATUS"] = "Смена статуса заказа";
 $MESS["USH_TG_OPT_SEND_ORDER_PAY"] = "Оплата заказа";
+$MESS["USH_TG_OPT_SEND_ORDER_CANCELED"] = "Отмена заказа";
 $MESS["USH_TG_OPT_SEND_USER_REGISTERED"] = "Регистрация пользователя";
 $MESS["USH_TG_OPT_SEND_FORM_NEW"] = "Новая заявка (через почтовые события)";
 

--- a/options.php
+++ b/options.php
@@ -65,6 +65,8 @@ $aTabs = [
             ["SEND_ORDER_NEW", Loc::getMessage("USH_TG_OPT_SEND_ORDER_NEW"), "Y", ["checkbox"]],
             ["SEND_ORDER_STATUS", Loc::getMessage("USH_TG_OPT_SEND_ORDER_STATUS"), "Y", ["checkbox"]],
             ["SEND_ORDER_PAY", Loc::getMessage("USH_TG_OPT_SEND_ORDER_PAY"), "Y", ["checkbox"]],
+            ["SEND_ORDER_CANCELED", Loc::getMessage("USH_TG_OPT_SEND_ORDER_CANCELED"), "Y", ["checkbox"]],
+            ["SEND_ORDER_UNCANCELED", "Снятие отмены заказа", "Y", ["checkbox"]],
             ["SEND_USER_REGISTERED", Loc::getMessage("USH_TG_OPT_SEND_USER_REGISTERED"), "N", ["checkbox"]],
             ["SEND_FORM_NEW", Loc::getMessage("USH_TG_OPT_SEND_FORM_NEW"), "N", ["checkbox"]],
 
@@ -73,6 +75,8 @@ $aTabs = [
             ["TPL_ORDER_NEW", Loc::getMessage("USH_TG_TPL_ORDER_NEW"), Loc::getMessage("USH_TG_TPL_ORDER_NEW_DEF"), ["textarea", 6, 60]],
             ["TPL_ORDER_STATUS", Loc::getMessage("USH_TG_TPL_ORDER_STATUS"), Loc::getMessage("USH_TG_TPL_ORDER_STATUS_DEF"), ["textarea", 6, 60]],
             ["TPL_ORDER_PAY", Loc::getMessage("USH_TG_TPL_ORDER_PAY"), Loc::getMessage("USH_TG_TPL_ORDER_PAY_DEF"), ["textarea", 6, 60]],
+            ["TPL_ORDER_CANCELED", "Шаблон: отмена заказа", "❌ Заказ #ORDER_ID# отменён\nПричина: #REASON#\nСумма: #PRICE#\nСсылка: #ADMIN_URL#", ["textarea", 6, 60]],
+            ["TPL_ORDER_UNCANCELED", "Шаблон: снятие отмены", "♻️ Отмена заказа #ORDER_ID# снята\nСумма: #PRICE#\nСсылка: #ADMIN_URL#", ["textarea", 6, 60]],
             ["TPL_USER_REGISTERED", Loc::getMessage("USH_TG_TPL_USER_REGISTERED"), Loc::getMessage("USH_TG_TPL_USER_REGISTERED_DEF"), ["textarea", 5, 60]],
             ["TPL_FORM_NEW", Loc::getMessage("USH_TG_TPL_FORM_NEW"), Loc::getMessage("USH_TG_TPL_FORM_NEW_DEF"), ["textarea", 6, 60]],
         ],


### PR DESCRIPTION
…ация; события: новый заказ, смена статуса (читаемое имя, сумма), оплата (определение ПС), отмена и снятие отмены; webhook.php улучшен (секрет, payload, SQL, 200 без BOT_TOKEN); добавлены строки перевода